### PR TITLE
Add parallel-ringing Find Me example (extension 7000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ exten => _X.,1,NoOp(Call Entry DNIS=${EXTEN})
  same => n(end),Hangup()
 ```
 
+## 🔔 Parallel Ringing (Simultaneous) Example
+
+Dial extension `7000` from an internal phone to trigger the parallel-ringing
+Find Me example. This will attempt to ring `6003` and `6004` at the same time
+for 30 seconds. If one of the endpoints is not registered or unreachable,
+PJSIP will typically ignore that contact and ring the available ones.
+
+Example behavior:
+- Call 7000 -> Asterisk executes Dial(PJSIP/6003&PJSIP/6004,30)
+- All listed endpoints ring simultaneously
+- If any endpoint answers, the call is bridged and the dialplan continues
+	(DIALSTATUS will be ANSWER)
+- If none answer, the existing Find Me fallback logic and voicemail will
+	be used as configured in the dialplan
+
+This example is intended for demonstration and can be expanded by adding
+more endpoints to the dial string (separated by `&`) or by inserting
+pre-checks to filter only registered contacts if your deployment requires it.
+
 ## 🧩 Version Compatibility
 
 - **Tested on:** Asterisk 22.x

--- a/dialplan/extensions.conf
+++ b/dialplan/extensions.conf
@@ -14,6 +14,30 @@ exten => _X.,1,NoOp(Call Entry DNIS=${EXTEN})
  same => n,Dial(PJSIP/6002,20,g)
  same => n,Verbose("After Dial: DIALSTATUS=${DIALSTATUS}")
 
+ ; ------------------------------------------------------------------
+ ; Parallel Find-Me example
+ ; Dial extension 7000 to ring multiple PJSIP endpoints simultaneously.
+ ; This demonstrates "parallel ringing" (simultaneous ring) of multiple
+ ; endpoints using the `&` list in Dial(). Asterisk will attempt to ring
+ ; all specified endpoints at once. If some endpoints are not registered
+ ; or have no active contacts, they will typically be skipped by PJSIP.
+ ; ------------------------------------------------------------------
+ exten => 7000,1,NoOp(Parallel Find-Me: Ring multiple endpoints simultaneously)
+	same => n,Verbose("Parallel Find-Me example: attempting to ring 6003 & 6004")
+	same => n,Set(RING_TIME=30)
+	; Build the simultaneous dial string here. Add more endpoints separated
+	; by '&' if desired: e.g. PJSIP/6003&PJSIP/6004&PJSIP/6005
+	same => n,Set(DIAL_TARGETS=PJSIP/6003&PJSIP/6004)
+	; Dial the targets simultaneously. The 'g' option returns to dialplan on
+	; answer so we can inspect DIALSTATUS. Adjust options as needed.
+	same => n,Dial(${DIAL_TARGETS},${RING_TIME},g)
+	same => n,Verbose("Parallel Dial finished: DIALSTATUS=${DIALSTATUS}")
+	; If answered, jump to end. Otherwise reuse the existing call_failed
+	; handling (which will check FINDME_ENABLED and continue sequential
+	; find-me if enabled, or go to voicemail).
+	same => n,GotoIf($["${DIALSTATUS}"="ANSWER"]?end:call_failed)
+
+
  ; Only handle failed or non-answered calls here
  same => n,GotoIf($["${DIALSTATUS}"="ANSWER"]?end:call_failed)
 

--- a/documents/parallel_findme.txt
+++ b/documents/parallel_findme.txt
@@ -1,0 +1,31 @@
+Parallel Find-Me (Simultaneous Ringing) Example
+
+Overview:
+- Dial extension 7000 from any internal phone in this example.
+- Asterisk will attempt to ring PJSIP/6003 and PJSIP/6004 at the same time for 30 seconds.
+- If any endpoint answers, the call is bridged to the answering endpoint.
+- If none answer, the dialplan falls back to the existing Find Me sequence and/or voicemail.
+
+How it works:
+- The dialplan builds a dial string containing multiple PJSIP endpoints separated by '&'.
+  Example: PJSIP/6003&PJSIP/6004
+- The Dial() application with that string rings all endpoints simultaneously.
+- The 'g' option on Dial returns control to the dialplan upon answer so the
+  call flow can inspect ${DIALSTATUS} and proceed accordingly.
+
+Notes and extensions:
+- You can add more endpoints to the DIAL_TARGETS variable separated with '&',
+  for example: PJSIP/6003&PJSIP/6004&PJSIP/6005
+- In environments where you want to avoid dialing unregistered endpoints, add
+  a pre-check to only include endpoints with active contacts. This repo's
+  example keeps the dialstring simple for clarity.
+- Adjust RING_TIME to control how long the endpoints ring.
+
+Testing:
+1. Register clients for 6003 and 6004 (softphones or devices).
+2. Call 7000 from an internal extension.
+3. Observe both endpoints ringing.
+4. Answer on one endpoint and verify the call is bridged.
+5. Let the call time out and confirm the fallback logic runs.
+
+This file is for demonstration and reference only.


### PR DESCRIPTION
This PR adds a parallel-ringing Find Me demonstration to the dialplan.\n\nFiles changed:\n- dialplan/extensions.conf: Added extension 7000 which dials PJSIP/6003&PJSIP/6004 simultaneously for 30s and integrates with existing Find Me fallback logic.\n- README.md: Documented the parallel-ringing example and expected behavior.\n- documents/parallel_findme.txt: Added testing and usage notes.\n\nTesting notes: Register endpoints 6003 and 6004, call 7000, and confirm simultaneous ringing and fallback behavior when no answer.